### PR TITLE
adding a --all switch to seinfo

### DIFF
--- a/seinfo
+++ b/seinfo
@@ -31,95 +31,106 @@ parser.add_argument(
 
 queries = parser.add_argument_group("Component Queries")
 queries.add_argument("-c", "--class", help="Print object classes.",
-                     dest="classquery", default="", nargs='?', const=True, metavar="CLASS")
+                     dest="classquery", default=None, nargs='?', const=True, metavar="CLASS")
 queries.add_argument("-t", "--type",  help="Print types.",
-                     dest="typequery",  default="", nargs='?', const=True, metavar="TYPE")
+                     dest="typequery",  default=None, nargs='?', const=True, metavar="TYPE")
 queries.add_argument("-a", "--attribute",  help="Print type attributes.",
-                     dest="attrquery",  default="", nargs='?', const=True, metavar="ATTR")
+                     dest="attrquery",  default=None, nargs='?', const=True, metavar="ATTR")
 queries.add_argument("-r", "--role",  help="Print roles.",
-                     dest="rolequery",  default="", nargs='?', const=True, metavar="ROLE")
+                     dest="rolequery",  default=None, nargs='?', const=True, metavar="ROLE")
 queries.add_argument("-u", "--user",  help="Print users.",
-                     dest="userquery",  default="", nargs='?', const=True, metavar="USER")
+                     dest="userquery",  default=None, nargs='?', const=True, metavar="USER")
 queries.add_argument("-b", "--bool",  help="Print Booleans.",
-                     dest="boolquery",  default="", nargs='?', const=True, metavar="BOOL")
+                     dest="boolquery",  default=None, nargs='?', const=True, metavar="BOOL")
 queries.add_argument("--sensitivity",  help="Print MLS sensitivities.",
-                     dest="mlssensquery",  default="", nargs='?', const=True, metavar="SENS")
+                     dest="mlssensquery",  default=None, nargs='?', const=True, metavar="SENS")
 queries.add_argument("--category",  help="Print MLS categories.",
-                     dest="mlscatsquery",  default="", nargs='?', const=True, metavar="CAT")
+                     dest="mlscatsquery",  default=None, nargs='?', const=True, metavar="CAT")
 queries.add_argument("--constrain",  help="Print constraints.",
-                     dest="constraintquery",  default="", nargs='?', const=True, metavar="CLASS")
+                     dest="constraintquery",  default=None, nargs='?', const=True, metavar="CLASS")
 queries.add_argument("--initialsid",  help="Print initial SIDs (contexts).",
-                     dest="initialsidquery",  default="", nargs='?', const=True, metavar="NAME")
+                     dest="initialsidquery",  default=None, nargs='?', const=True, metavar="NAME")
 queries.add_argument("--fs_use",  help="Print fs_use statements.",
-                     dest="fsusequery",  default="", nargs='?', const=True, metavar="FS_TYPE")
+                     dest="fsusequery",  default=None, nargs='?', const=True, metavar="FS_TYPE")
 queries.add_argument("--genfscon",  help="Print genfscon statements.",
-                     dest="genfsconquery",  default="", nargs='?', const=True, metavar="FS_TYPE")
+                     dest="genfsconquery",  default=None, nargs='?', const=True, metavar="FS_TYPE")
 queries.add_argument("--netifcon",  help="Print netifcon statements.",
-                     dest="netifconquery",  default="", nargs='?', const=True, metavar="DEVICE")
+                     dest="netifconquery",  default=None, nargs='?', const=True, metavar="DEVICE")
 queries.add_argument("--nodecon",  help="Print nodecon statements.",
-                     dest="nodeconquery",  default="", nargs='?', const=True, metavar="ADDR")
+                     dest="nodeconquery",  default=None, nargs='?', const=True, metavar="ADDR")
 queries.add_argument("--portcon",  help="Print portcon statements.",
-                     dest="portconquery",  default="", nargs='?', const=True, metavar="PORTNUM[-PORTNUM]")
+                     dest="portconquery",  default=None, nargs='?', const=True, metavar="PORTNUM[-PORTNUM]")
 queries.add_argument("--permissive",  help="Print permissive statements.",
-                     dest="permissivequery", default="", nargs='?', const=True, metavar="TYPE")
+                     dest="permissivequery", default=None, nargs='?', const=True, metavar="TYPE")
 queries.add_argument("--polcap",  help="Print policy capabilities.",
-                     dest="polcapquery", default="", nargs='?', const=True, metavar="NAME")
+                     dest="polcapquery", default=None, nargs='?', const=True, metavar="NAME")
+queries.add_argument("--all",  help="Print all of the above.",
+                     dest="all", default=False, action="store_true")
 
 args = parser.parse_args()
 
 try:
     p = setools.SELinuxPolicy(args.policy)
+    components = []
 
-    if args.boolquery:
+    if args.boolquery or args.all:
         if isinstance(args.boolquery, str):
             q = setools.boolquery.BoolQuery(p, name=args.boolquery)
         else:
             q = setools.boolquery.BoolQuery(p)
+        components.append(("Booleans", q))
 
-    elif args.classquery:
+    if args.classquery or args.all:
         if isinstance(args.classquery, str):
             q = setools.objclassquery.ObjClassQuery(p, name=args.classquery)
         else:
             q = setools.objclassquery.ObjClassQuery(p)
+        components.append(("Classes", q))
 
-    elif args.fsusequery:
+    if args.fsusequery or args.all:
         if isinstance(args.fsusequery, str):
             q = setools.fsusequery.FSUseQuery(p, fs=args.fsusequery)
         else:
             q = setools.fsusequery.FSUseQuery(p)
+        components.append(("Fs_use", q))
 
-    elif args.genfsconquery:
+    if args.genfsconquery or args.all:
         if isinstance(args.genfsconquery, str):
             q = setools.genfsconquery.GenfsconQuery(p, fs=args.genfsconquery)
         else:
             q = setools.genfsconquery.GenfsconQuery(p)
+        components.append(("Genfscon", q))
 
-    elif args.initialsidquery:
+    if args.initialsidquery or args.all:
         if isinstance(args.initialsidquery, str):
             q = setools.initsidquery.InitialSIDQuery(
                 p, name=args.initialsidquery)
         else:
             q = setools.initsidquery.InitialSIDQuery(p)
+        components.append(("Initial SIDs", q))
 
-    elif args.netifconquery:
+    if args.netifconquery or args.all:
         if isinstance(args.netifconquery, str):
             q = setools.netifconquery.NetifconQuery(p, name=args.netifconquery)
         else:
             q = setools.netifconquery.NetifconQuery(p)
+        components.append(("Netifcon", q))
 
-    elif args.nodeconquery:
+    if args.nodeconquery or args.all:
         if isinstance(args.nodeconquery, str):
             q = setools.nodeconquery.NodeconQuery(p, net=args.nodeconquery)
         else:
             q = setools.nodeconquery.NodeconQuery(p)
+        components.append(("Nodecon", q))
 
-    elif args.polcapquery:
+    if args.polcapquery or args.all:
         if isinstance(args.polcapquery, str):
             q = setools.polcapquery.PolCapQuery(p, name=args.polcapquery)
         else:
             q = setools.polcapquery.PolCapQuery(p)
+        components.append(("Polcap", q))
 
-    elif args.portconquery:
+    if args.portconquery or args.all:
         if isinstance(args.portconquery, str):
             q = setools.portconquery.PortconQuery(p)
 
@@ -139,26 +150,30 @@ try:
 
         else:
             q = setools.portconquery.PortconQuery(p)
+        components.append(("Portcon", q))
 
-    elif args.rolequery:
+    if args.rolequery or args.all:
         if isinstance(args.rolequery, str):
             q = setools.rolequery.RoleQuery(p, name=args.rolequery)
         else:
             q = setools.rolequery.RoleQuery(p)
+        components.append(("Roles", q))
 
-    elif args.typequery:
+    if args.typequery or args.all:
         if isinstance(args.typequery, str):
             q = setools.typequery.TypeQuery(p, name=args.typequery)
         else:
             q = setools.typequery.TypeQuery(p)
+        components.append(("Types", q))
 
-    elif args.userquery:
+    if args.userquery or args.all:
         if isinstance(args.userquery, str):
             q = setools.userquery.UserQuery(p, name=args.userquery)
         else:
             q = setools.userquery.UserQuery(p)
+        components.append(("Users", q))
 
-    else:
+    if not components or args.all:
         if p.mls:
             mls = "enabled"
         else:
@@ -198,13 +213,18 @@ try:
             p.netifcon_count, p.nodecon_count))
         print("  Permissives:   {0:7}    Polcap:        {1:7}".format(
             p.permissives_count, p.polcap_count))
-        sys.exit(0)
 
-    for item in sorted(q.results()):
-        if args.expand:
-            print(item.statement())
-        else:
-            print(item)
+    for desc, component in components:
+        results = sorted(component.results())
+        print("\n{0}: {1}".format(desc, len(results)))
+        for item in results:
+            if args.expand:
+                result = item.statement()
+            else:
+                result = item
+            print("   {0}".format(result))
+
+    sys.exit(0)
 
 except Exception as err:
     print(err)

--- a/seinfo
+++ b/seinfo
@@ -66,6 +66,8 @@ queries.add_argument("--polcap",  help="Print policy capabilities.",
                      dest="polcapquery", default=None, nargs='?', const=True, metavar="NAME")
 queries.add_argument("--all",  help="Print all of the above.",
                      dest="all", default=False, action="store_true")
+queries.add_argument("--flat",  help="Print without item count nor indentation.",
+                     dest="flat", default=False, action="store_true")
 
 args = parser.parse_args()
 
@@ -173,7 +175,7 @@ try:
             q = setools.userquery.UserQuery(p)
         components.append(("Users", q))
 
-    if not components or args.all:
+    if (not components or args.all) and not args.flat:
         if p.mls:
             mls = "enabled"
         else:
@@ -216,13 +218,12 @@ try:
 
     for desc, component in components:
         results = sorted(component.results())
-        print("\n{0}: {1}".format(desc, len(results)))
+        if not args.flat:
+            print("\n{0}: {1}".format(desc, len(results)))
         for item in results:
-            if args.expand:
-                result = item.statement()
-            else:
-                result = item
-            print("   {0}".format(result))
+            result = item.statement() if args.expand else item
+            strfmt = "   {0}" if not args.flat else"{0}"
+            print(strfmt.format(result))
 
     sys.exit(0)
 


### PR DESCRIPTION
There are 3 major changes in this commit:

1/ Setting the default values to None instead of "". Indeed, when --all is
   passed to the command line, default values are set to "" making the
   'if insinstance(xxx, str)' being True, and thus the script takes the wrong
   branch.
2/ if/elif/else have been replaced by if/else structure, to enable selection of
   multiple switches. Selected component queries are stacked and displayed at
   the end
3/ like the original seinfo, we append some descriptions string (info: count +
   indented results) to the output