### PR TITLE
policyrep: sort categories using their index

### DIFF
--- a/setools/policyrep/mls.py
+++ b/setools/policyrep/mls.py
@@ -244,6 +244,10 @@ class Category(BaseMLSComponent):
         stmt += ";"
         return stmt
 
+    def __lt__(self, other):
+        """Comparison based on their index instead of their names."""
+        return self._value < other._value
+
 
 class Sensitivity(BaseMLSComponent):
 


### PR DESCRIPTION
Here is a patch to have categories sorted by order of appearance in the policy file instead of names (default behavior).