### PR TITLE
Fix warnings reported by clang

### DIFF
--- a/libqpol/include/qpol/avrule_query.h
+++ b/libqpol/include/qpol/avrule_query.h
@@ -66,7 +66,7 @@ extern "C"
  *  to free memory used by this iterator.
  *  It is important to note that this iterator is only valid as long as
  *  the policy is unmodifed.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *iter will be NULL.
  */
 	extern int qpol_policy_get_avrule_iter(const qpol_policy_t * policy, uint32_t rule_type_mask, qpol_iterator_t ** iter);
@@ -77,7 +77,7 @@ extern "C"
  *  @param rule The rule from which to get the source type.
  *  @param source Pointer in which to store the source type.
  *  The caller should not free this pointer.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *source will be NULL.
  */
 	extern int qpol_avrule_get_source_type(const qpol_policy_t * policy, const qpol_avrule_t * rule,
@@ -89,7 +89,7 @@ extern "C"
  *  @param rule The rule from which to get the target type.
  *  @param target Pointer in which to store the target type.
  *  The caller should not free this pointer.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *target will be NULL.
  */
 	extern int qpol_avrule_get_target_type(const qpol_policy_t * policy, const qpol_avrule_t * rule,
@@ -101,7 +101,7 @@ extern "C"
  *  @param rule The rule from which to get the object class.
  *  @param obj_class Pointer in which to store the object class.
  *  The caller should not free this pointer.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *obj_class will be NULL.
  */
 	extern int qpol_avrule_get_object_class(const qpol_policy_t * policy, const qpol_avrule_t * rule,
@@ -118,7 +118,7 @@ extern "C"
  *  <b>free() on the strings returned by qpol_iterator_get_item().</b>
  *  It is important to note that this iterator is only valid as long as
  *  the policy is unmodifed.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *perms will be NULL.
  */
 	extern int qpol_avrule_get_perm_iter(const qpol_policy_t * policy, const qpol_avrule_t * rule, qpol_iterator_t ** perms);
@@ -128,13 +128,13 @@ extern "C"
  *  an error to call this function an an avrule that is not an extended avrule.
  *  @param policy Policy from which the rule comes.
  *  @param rule The rule from which to get the permissions.
- *  @param perms Iterator over items of type int* returned.
+ *  @param xperms Iterator over items of type int* returned.
  *  The caller is responsible for calling qpol_iterator_destroy()
  *  to free memory used by this iterator. The caller <b>should call</b>
  *  <b>free() on the ints returned by qpol_iterator_get_item().</b>
  *  It is important to note that this iterator is only valid as long as
  *  the policy is unmodifed.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *xperms will be NULL.
  */
 	extern int qpol_avrule_get_xperm_iter(const qpol_policy_t * policy, const qpol_avrule_t * rule, qpol_iterator_t ** xperms);
@@ -166,7 +166,7 @@ extern "C"
  *  @param rule The rule from which to get the rule type.
  *  @param rule_type Integer in which to store the rule type value.
  *  The value will be one of the QPOL_RULE_* values above.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *rule_type will be 0.
  */
 	extern int qpol_avrule_get_rule_type(const qpol_policy_t * policy, const qpol_avrule_t * rule, uint32_t * rule_type);

--- a/libqpol/include/qpol/class_perm_query.h
+++ b/libqpol/include/qpol/class_perm_query.h
@@ -135,7 +135,7 @@ extern "C"
 /**
  *  Get the name which identifies a class.
  *  @param policy The policy with which the class is associated.
- *  @param datum Class for which to get the name. Must be non-NULL.
+ *  @param obj_class Class for which to get the name. Must be non-NULL.
  *  @param name Pointer to the string in which to store the name.
  *  Must be non-NULL. Caller should not free the string.
  *  @return Returns 0 on success and < 0 on failure; if the call fails,

--- a/libqpol/include/qpol/cond_query.h
+++ b/libqpol/include/qpol/cond_query.h
@@ -84,7 +84,7 @@ extern "C"
  *  to free memory used by this iterator.
  *  It is important to note that this iterator is only valid as long as
  *  the policy is unmodifed.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *iter will be NULL.
  */
 	extern int qpol_cond_get_av_true_iter(const qpol_policy_t * policy, const qpol_cond_t * cond, uint32_t rule_type_mask,
@@ -102,7 +102,7 @@ extern "C"
  *  to free memory used by this iterator.
  *  It is important to note that this iterator is only valid as long as
  *  the policy is unmodifed.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *iter will be NULL.
  */
 	extern int qpol_cond_get_te_true_iter(const qpol_policy_t * policy, const qpol_cond_t * cond, uint32_t rule_type_mask,
@@ -120,7 +120,7 @@ extern "C"
  *  to free memory used by this iterator.
  *  It is important to note that this iterator is only valid as long as
  *  the policy is unmodifed.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *iter will be NULL.
  */
 	extern int qpol_cond_get_av_false_iter(const qpol_policy_t * policy, const qpol_cond_t * cond, uint32_t rule_type_mask,
@@ -138,7 +138,7 @@ extern "C"
  *  to free memory used by this iterator.
  *  It is important to note that this iterator is only valid as long as
  *  the policy is unmodifed.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *iter will be NULL.
  */
 	extern int qpol_cond_get_te_false_iter(const qpol_policy_t * policy, const qpol_cond_t * cond, uint32_t rule_type_mask,

--- a/libqpol/include/qpol/constraint_query.h
+++ b/libqpol/include/qpol/constraint_query.h
@@ -148,7 +148,7 @@ extern "C"
 
 /**
  *  Get the code for the expression type of by an expression node.
- *  @patam policy The policy from which the expression comes.
+ *  @param policy The policy from which the expression comes.
  *  @param expr The expression node from which to get the expression type.
  *  @param expr_type Integer in which to store the expression type; the value
  *  will be one of QPOL_CEXPR_TYPE_* above.

--- a/libqpol/include/qpol/default_object_query.h
+++ b/libqpol/include/qpol/default_object_query.h
@@ -65,7 +65,7 @@ extern "C"
  *  Get the value of a default user source/dest from its datum.
  *  @param policy The policy with which the default object is associated.
  *  @param datum default_object datum for which to get the value. Must be non-NULL.
- *  @param default Pointer to the value in which to store the default.
+ *  @param value Pointer to the value in which to store the default.
  *  Must be non-NULL. The caller should not free the string.
  *  @return Returns 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *default will be 0.
@@ -76,7 +76,7 @@ extern "C"
  *  Get the value of a default role source/dest from its datum.
  *  @param policy The policy with which the default object type is associated.
  *  @param datum default_object datum for which to get the value. Must be non-NULL.
- *  @param default Pointer to the value in which to store the default.
+ *  @param value Pointer to the value in which to store the default.
  *  Must be non-NULL. The caller should not free the string.
  *  @return Returns 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *default will be 0.
@@ -87,7 +87,7 @@ extern "C"
  *  Get the value of a default type source/dest from its datum.
  *  @param policy The policy with which the default object type is associated.
  *  @param datum default_object datum for which to get the value. Must be non-NULL.
- *  @param default Pointer to the value in which to store the default.
+ *  @param value Pointer to the value in which to store the default.
  *  Must be non-NULL. The caller should not free the string.
  *  @return Returns 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *default will be 0.
@@ -98,7 +98,7 @@ extern "C"
  *  Get the value of a default range source/dest from its datum.
  *  @param policy The policy with which the default object type is associated.
  *  @param datum default_object datum for which to get the value. Must be non-NULL.
- *  @param default Pointer to the value in which to store the default.
+ *  @param value Pointer to the value in which to store the default.
  *  Must be non-NULL. The caller should not free the string.
  *  @return Returns 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *default will be 0.

--- a/libqpol/include/qpol/ftrule_query.h
+++ b/libqpol/include/qpol/ftrule_query.h
@@ -101,7 +101,7 @@ extern "C"
  *  Get the filename from a filename transition rule.
  *  @param policy Policy from which the rule comes.
  *  @param rule The rule from which to get the transition filename.
- *  @param target Pointer in which to store the filename.
+ *  @param name Pointer in which to store the filename.
  *  The caller should not free this pointer.
  *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *target will be NULL.

--- a/libqpol/include/qpol/mlsrule_query.h
+++ b/libqpol/include/qpol/mlsrule_query.h
@@ -44,7 +44,7 @@ extern "C"
  *  to free memory used by this iterator.
  *  It is important to note that this iterator is only valid as long as
  *  the policy is unmodifed.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *iter will be NULL.
  */
 	extern int qpol_policy_get_range_trans_iter(const qpol_policy_t * policy, qpol_iterator_t ** iter);
@@ -55,7 +55,7 @@ extern "C"
  *  @param rule The rule from which to get the source type.
  *  @param source Pointer in which to store the source type.
  *  The caller should not free this pointer.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *source will be NULL.
  */
 	extern int qpol_range_trans_get_source_type(const qpol_policy_t * policy, const qpol_range_trans_t * rule,
@@ -67,7 +67,7 @@ extern "C"
  *  @param rule The rule from which to get the target type.
  *  @param target Pointer in which to store the target type.
  *  The caller should not free this pointer.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *target will be NULL.
  */
 	extern int qpol_range_trans_get_target_type(const qpol_policy_t * policy, const qpol_range_trans_t * rule,
@@ -79,7 +79,7 @@ extern "C"
  *  @param rule The rule from which to get the target class.
  *  @param target Pointer in which to store the target class.
  *  The caller should not free this pointer.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *target will be NULL.
  */
 	extern int qpol_range_trans_get_target_class(const qpol_policy_t * policy, const qpol_range_trans_t * rule,
@@ -91,7 +91,7 @@ extern "C"
  *  @param rule The rule from which to get the range.
  *  @param range Pointer in which to store the range.
  *  The caller should not free this pointer.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *range will be NULL.
  */
 	extern int qpol_range_trans_get_range(const qpol_policy_t * policy, const qpol_range_trans_t * rule,

--- a/libqpol/include/qpol/netifcon_query.h
+++ b/libqpol/include/qpol/netifcon_query.h
@@ -77,7 +77,7 @@ extern "C"
  *  Get the message context from a netifcon statement.
  *  @param policy The policy associated with the netifcon statement.
  *  @param ocon The netifcon statement from which to get the message context.
- *  @parma context Pointer in which to store the context.
+ *  @param context Pointer in which to store the context.
  *  The caller should not free this pointer.
  *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *context will be NULL.
@@ -89,7 +89,7 @@ extern "C"
  *  Get the interface context from a netifcon statement.
  *  @param policy The policy associated with the netifcon statement.
  *  @param ocon The netifcon statement from which to get the interface context.
- *  @parma context Pointer in which to store the context.
+ *  @param context Pointer in which to store the context.
  *  The caller should not free this pointer.
  *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *context will be NULL.

--- a/libqpol/include/qpol/rbacrule_query.h
+++ b/libqpol/include/qpol/rbacrule_query.h
@@ -45,7 +45,7 @@ extern "C"
  *  to free memory used by this iterator.
  *  It is important to note that this iterator is only valid as long as
  *  the policy is unmodifed.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *iter will be NULL.
  */
 	extern int qpol_policy_get_role_allow_iter(const qpol_policy_t * policy, qpol_iterator_t ** iter);
@@ -82,7 +82,7 @@ extern "C"
  *  to free memory used by this iterator.
  *  It is important to note that this iterator is only valid as long as
  *  the policy is unmodifed.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *iter will be NULL.
  */
 	extern int qpol_policy_get_role_trans_iter(const qpol_policy_t * policy, qpol_iterator_t ** iter);

--- a/libqpol/include/qpol/terule_query.h
+++ b/libqpol/include/qpol/terule_query.h
@@ -53,7 +53,7 @@ extern "C"
  *  to free memory used by this iterator.
  *  It is important to note that this iterator is only valid as long as
  *  the policy is unmodifed.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *iter will be NULL.
  */
 	extern int qpol_policy_get_terule_iter(const qpol_policy_t * policy, uint32_t rule_type_mask, qpol_iterator_t ** iter);
@@ -64,7 +64,7 @@ extern "C"
  *  @param rule The rule from which to get the source type.
  *  @param source Pointer in which to store the source type.
  *  The caller should not free this pointer.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *source will be NULL.
  */
 	extern int qpol_terule_get_source_type(const qpol_policy_t * policy, const qpol_terule_t * rule,
@@ -76,7 +76,7 @@ extern "C"
  *  @param rule The rule from which to get the target type.
  *  @param target Pointer in which to store the target type.
  *  The caller should not free this pointer.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *target will be NULL.
  */
 	extern int qpol_terule_get_target_type(const qpol_policy_t * policy, const qpol_terule_t * rule,
@@ -88,7 +88,7 @@ extern "C"
  *  @param rule The rule from which to get the object class.
  *  @param obj_class Pointer in which to store the object class.
  *  The caller should not free this pointer.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *obj_class will be NULL.
  */
 	extern int qpol_terule_get_object_class(const qpol_policy_t * policy, const qpol_terule_t * rule,
@@ -100,7 +100,7 @@ extern "C"
  *  @param rule The rule from which to get the default type.
  *  @param dflt Pointer in which to store the default type.
  *  The caller should not free this pointer.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *dflt will be NULL.
  */
 	extern int qpol_terule_get_default_type(const qpol_policy_t * policy, const qpol_terule_t * rule,
@@ -112,7 +112,7 @@ extern "C"
  *  @param rule The rule from which to get the rule type.
  *  @param rule_type Integer in which to store the rule type value.
  *  The value will be one of the QPOL_RULE_* values above.
- *  @returm 0 on success and < 0 on failure; if the call fails,
+ *  @return 0 on success and < 0 on failure; if the call fails,
  *  errno will be set and *rule_type will be 0.
  */
 	extern int qpol_terule_get_rule_type(const qpol_policy_t * policy, const qpol_terule_t * rule, uint32_t * rule_type);

--- a/setools/policyrep/qpol.i
+++ b/setools/policyrep/qpol.i
@@ -1294,7 +1294,7 @@ typedef struct qpol_type {} qpol_type_t;
 %inline %{
     qpol_type_t *qpol_type_from_void(void *x) {
         return (qpol_type_t*)x;
-    };
+    }
 %}
 
 /* qpol role */
@@ -1358,7 +1358,7 @@ typedef struct qpol_role {} qpol_role_t;
 %inline %{
     qpol_role_t *qpol_role_from_void(void *x) {
         return (qpol_role_t*)x;
-    };
+    }
 %}
 
 /* qpol level */
@@ -1437,7 +1437,7 @@ typedef struct qpol_level {} qpol_level_t;
 %inline %{
     qpol_level_t *qpol_level_from_void(void *x) {
         return (qpol_level_t*)x;
-    };
+    }
 %}
 
 /* qpol cat */
@@ -1504,7 +1504,7 @@ typedef struct qpol_cat {} qpol_cat_t;
 %inline %{
     qpol_cat_t *qpol_cat_from_void(void *x) {
         return (qpol_cat_t*)x;
-    };
+    }
 %}
 
 /* qpol mls range */
@@ -1558,7 +1558,7 @@ typedef struct qpol_mls_range {} qpol_mls_range_t;
 %inline %{
     qpol_mls_range_t *qpol_mls_range_from_void(void *x) {
         return (qpol_mls_range_t*)x;
-    };
+    }
 %}
 
 /* qpol semantic mls level */
@@ -1639,7 +1639,7 @@ typedef struct qpol_mls_level {} qpol_mls_level_t;
 %inline %{
     qpol_mls_level_t *qpol_mls_level_from_void(void *x) {
         return (qpol_mls_level_t*)x;
-    };
+    }
 %}
 
 /* qpol user */
@@ -1709,7 +1709,7 @@ typedef struct qpol_user {} qpol_user_t;
 %inline %{
     qpol_user_t *qpol_user_from_void(void *x) {
         return (qpol_user_t*)x;
-    };
+    }
 %}
 
 /* qpol bool */
@@ -1756,7 +1756,7 @@ typedef struct qpol_bool {} qpol_bool_t;
 %inline %{
     qpol_bool_t *qpol_bool_from_void(void *x) {
         return (qpol_bool_t*)x;
-    };
+    }
 %}
 
 /* qpol context */
@@ -1807,7 +1807,7 @@ typedef struct qpol_context {} qpol_context_t;
 %inline %{
     qpol_context_t *qpol_context_from_void(void *x) {
         return (qpol_context_t*)x;
-    };
+    }
 %}
 
 /* qpol class */
@@ -1904,7 +1904,7 @@ typedef struct qpol_class {} qpol_class_t;
 %inline %{
     qpol_class_t *qpol_class_from_void(void *x) {
         return (qpol_class_t*)x;
-    };
+    }
 %}
 
 /* qpol common */
@@ -1964,7 +1964,7 @@ typedef struct qpol_common {} qpol_common_t;
 %inline %{
     qpol_common_t *qpol_common_from_void(void *x) {
         return (qpol_common_t*)x;
-    };
+    }
 %}
 
 /* qpol fs_use */
@@ -2023,7 +2023,7 @@ typedef struct qpol_fs_use {} qpol_fs_use_t;
 %inline %{
     qpol_fs_use_t *qpol_fs_use_from_void(void *x) {
         return (qpol_fs_use_t*)x;
-    };
+    }
 %}
 
 /* qpol genfscon */
@@ -2095,7 +2095,7 @@ typedef struct qpol_genfscon {} qpol_genfscon_t;
 %inline %{
     qpol_genfscon_t *qpol_genfscon_from_void(void *x) {
         return (qpol_genfscon_t*)x;
-    };
+    }
 %}
 
 /* qpol isid */
@@ -2143,7 +2143,7 @@ typedef struct qpol_isid {} qpol_isid_t;
 %inline %{
     qpol_isid_t *qpol_isid_from_void(void *x) {
         return (qpol_isid_t*)x;
-    };
+    }
 %}
 
 /* qpol netifcon */
@@ -2189,7 +2189,7 @@ typedef struct qpol_netifcon {} qpol_netifcon_t;
 %inline %{
     qpol_netifcon_t *qpol_netifcon_from_void(void *x) {
         return (qpol_netifcon_t*)x;
-    };
+    }
 %}
 
 /* qpol nodecon */
@@ -2279,7 +2279,7 @@ typedef struct qpol_nodecon {} qpol_nodecon_t;
 %inline %{
     qpol_nodecon_t *qpol_nodecon_from_void(void *x) {
         return (qpol_nodecon_t*)x;
-    };
+    }
 %}
 
 /* qpol portcon */
@@ -2336,7 +2336,7 @@ typedef struct qpol_portcon {} qpol_portcon_t;
 %inline %{
     qpol_portcon_t *qpol_portcon_from_void(void *x) {
         return (qpol_portcon_t*)x;
-    };
+    }
 %}
 
 /* qpol constraint */
@@ -2384,7 +2384,7 @@ typedef struct qpol_constraint {} qpol_constraint_t;
 %inline %{
     qpol_constraint_t *qpol_constraint_from_void(void *x) {
         return (qpol_constraint_t*)x;
-    };
+    }
 %}
 
 /* qpol validatetrans */
@@ -2420,7 +2420,7 @@ typedef struct qpol_validatetrans {} qpol_validatetrans_t;
 %inline %{
     qpol_validatetrans_t *qpol_validatetrans_from_void(void *x) {
         return (qpol_validatetrans_t*)x;
-    };
+    }
 %}
 
 /* qpol constraint expression node */
@@ -2497,7 +2497,7 @@ typedef struct qpol_constraint_expr_node {} qpol_constraint_expr_node_t;
 %inline %{
     qpol_constraint_expr_node_t *qpol_constraint_expr_node_from_void(void *x) {
         return (qpol_constraint_expr_node_t*)x;
-    };
+    }
 %}
 
 /* qpol role allow */
@@ -2536,7 +2536,7 @@ typedef struct qpol_role_allow {} qpol_role_allow_t;
 %inline %{
     qpol_role_allow_t *qpol_role_allow_from_void(void *x) {
         return (qpol_role_allow_t*)x;
-    };
+    }
 %}
 
 /* qpol role trans */
@@ -2591,7 +2591,7 @@ typedef struct qpol_role_trans {} qpol_role_trans_t;
 %inline %{
     qpol_role_trans_t *qpol_role_trans_from_void(void *x) {
         return (qpol_role_trans_t*)x;
-    };
+    }
 %}
 
 /* qpol range trans */
@@ -2645,7 +2645,7 @@ typedef struct qpol_range_trans {} qpol_range_trans_t;
 %inline %{
     qpol_range_trans_t *qpol_range_trans_from_void(void *x) {
         return (qpol_range_trans_t*)x;
-    };
+    }
 %}
 
 /* qpol av rule */
@@ -2802,7 +2802,7 @@ typedef struct qpol_avrule {} qpol_avrule_t;
 %inline %{
     qpol_avrule_t *qpol_avrule_from_void(void *x) {
         return (qpol_avrule_t*)x;
-    };
+    }
 %}
 
 /* qpol te rule */
@@ -2919,7 +2919,7 @@ typedef struct qpol_terule {} qpol_terule_t;
 %inline %{
     qpol_terule_t *qpol_terule_from_void(void *x) {
         return (qpol_terule_t*)x;
-    };
+    }
 %}
 
 /* qpol conditional */
@@ -2994,7 +2994,7 @@ typedef struct qpol_cond {} qpol_cond_t;
 %inline %{
     qpol_cond_t *qpol_cond_from_void(void *x) {
         return (qpol_cond_t*)x;
-    };
+    }
 %}
 
 /* qpol conditional expression node */
@@ -3040,7 +3040,7 @@ typedef struct qpol_cond_expr_node {} qpol_cond_expr_node_t;
 %inline %{
     qpol_cond_expr_node_t *qpol_cond_expr_node_from_void(void *x) {
         return (qpol_cond_expr_node_t*)x;
-    };
+    }
 %}
 
 /* qpol filename trans */
@@ -3103,7 +3103,7 @@ typedef struct qpol_filename_trans {} qpol_filename_trans_t;
 %inline %{
     qpol_filename_trans_t *qpol_filename_trans_from_void(void *x) {
         return (qpol_filename_trans_t*)x;
-    };
+    }
 %}
 
 /* qpol polcap */
@@ -3131,7 +3131,7 @@ typedef struct qpol_polcap {} qpol_polcap_t;
 %inline %{
     qpol_polcap_t *qpol_polcap_from_void(void *x) {
         return (qpol_polcap_t*)x;
-    };
+    }
 %}
 
 /* qpol typebounds */
@@ -3166,7 +3166,7 @@ typedef struct qpol_typebounds {} qpol_typebounds_t;
 %inline %{
     qpol_typebounds_t *qpol_typebounds_from_void(void *x) {
         return (qpol_typebounds_t*)x;
-    };
+    }
 %}
 
 /* qpol rolebounds */
@@ -3201,7 +3201,7 @@ typedef struct qpol_rolebounds {} qpol_rolebounds_t;
 %inline %{
     qpol_rolebounds_t *qpol_rolebounds_from_void(void *x) {
         return (qpol_rolebounds_t*)x;
-    };
+    }
 %}
 
 /* qpol userbounds */
@@ -3236,7 +3236,7 @@ typedef struct qpol_userbounds {} qpol_userbounds_t;
 %inline %{
     qpol_userbounds_t *qpol_userbounds_from_void(void *x) {
         return (qpol_userbounds_t*)x;
-    };
+    }
 %}
 
 /* qpol default_object */
@@ -3298,7 +3298,7 @@ typedef struct qpol_default_object {} qpol_default_object_t;
 %inline %{
     qpol_default_object_t *qpol_default_object_from_void(void *x) {
         return (qpol_default_object_t*)x;
-    };
+    }
 %}
 
 /* qpol iomemcon */
@@ -3344,7 +3344,7 @@ typedef struct qpol_iomemcon {} qpol_iomemcon_t;
 %inline %{
     qpol_iomemcon_t *qpol_iomemcon_from_void(void *x) {
         return (qpol_iomemcon_t*)x;
-    };
+    }
 %}
 
 /* qpol ioportcon */
@@ -3390,7 +3390,7 @@ typedef struct qpol_ioportcon {} qpol_ioportcon_t;
 %inline %{
     qpol_ioportcon_t *qpol_ioportcon_from_void(void *x) {
         return (qpol_ioportcon_t*)x;
-    };
+    }
 %}
 
 /* qpol pcidevicecon */
@@ -3424,7 +3424,7 @@ typedef struct qpol_pcidevicecon {} qpol_pcidevicecon_t;
 %inline %{
     qpol_pcidevicecon_t *qpol_pcidevicecon_from_void(void *x) {
         return (qpol_pcidevicecon_t*)x;
-    };
+    }
 %}
 
 /* qpol pirqcon */
@@ -3458,7 +3458,7 @@ typedef struct qpol_pirqcon {} qpol_pirqcon_t;
 %inline %{
     qpol_pirqcon_t *qpol_pirqcon_from_void(void *x) {
         return (qpol_pirqcon_t*)x;
-    };
+    }
 %}
 
 /* qpol devicetreecon */
@@ -3491,6 +3491,6 @@ typedef struct qpol_devicetreecon {} qpol_devicetreecon_t;
 %inline %{
     qpol_devicetreecon_t *qpol_devicetreecon_from_void(void *x) {
         return (qpol_devicetreecon_t*)x;
-    };
+    }
 %}
 

--- a/setools/policyrep/qpol.i
+++ b/setools/policyrep/qpol.i
@@ -2674,14 +2674,14 @@ typedef struct qpol_avrule {} qpol_avrule_t;
             SWIG_exception(SWIG_ValueError, "Could not get rule type for av rule");
         }
         switch (rt) {
-            case QPOL_RULE_ALLOW: return "allow"; break;
-            case QPOL_RULE_NEVERALLOW: return "neverallow"; break;
-            case QPOL_RULE_AUDITALLOW: return "auditallow"; break;
-            case QPOL_RULE_DONTAUDIT: return "dontaudit"; break;
-            case QPOL_RULE_XPERMS_ALLOW: return "allowxperm"; break;
-            case QPOL_RULE_XPERMS_NEVERALLOW: return "neverallowxperm"; break;
-            case QPOL_RULE_XPERMS_AUDITALLOW: return "auditallowxperm"; break;
-            case QPOL_RULE_XPERMS_DONTAUDIT: return "dontauditxperm"; break;
+            case QPOL_RULE_ALLOW: return "allow";
+            case QPOL_RULE_NEVERALLOW: return "neverallow";
+            case QPOL_RULE_AUDITALLOW: return "auditallow";
+            case QPOL_RULE_DONTAUDIT: return "dontaudit";
+            case QPOL_RULE_XPERMS_ALLOW: return "allowxperm";
+            case QPOL_RULE_XPERMS_NEVERALLOW: return "neverallowxperm";
+            case QPOL_RULE_XPERMS_AUDITALLOW: return "auditallowxperm";
+            case QPOL_RULE_XPERMS_DONTAUDIT: return "dontauditxperm";
         }
     fail:
         return NULL;
@@ -2826,9 +2826,9 @@ typedef struct qpol_terule {} qpol_terule_t;
             SWIG_exception(SWIG_ValueError, "Could not get rule type for te rule");
         }
         switch (rt) {
-            case QPOL_RULE_TYPE_TRANS: return "type_transition"; break;
-            case QPOL_RULE_TYPE_CHANGE: return "type_change"; break;
-            case QPOL_RULE_TYPE_MEMBER: return "type_member"; break;
+            case QPOL_RULE_TYPE_TRANS: return "type_transition";
+            case QPOL_RULE_TYPE_CHANGE: return "type_change";
+            case QPOL_RULE_TYPE_MEMBER: return "type_member";
         }
     fail:
         return NULL;


### PR DESCRIPTION
Hello, I compiled setools 4 and ran its tests with clang and many warning flags (using ``CC=clang LDSHARED='clang --shared' python setup.py build test``). This resulted in some warnings: incorrect documentation tags, extra semicolon, ``break`` after ``return``, etc.
These three commits fix most of these warnings (thankfully nothing scary).