### PR TITLE
Add error check for missing libsepol.so

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -85,6 +85,12 @@ except KeyError:
     # this assumes that the static lib is in the same directory
     # as the dynamic lib.
     dynamic_sepol = UnixCCompiler().find_library_file(['.', '/usr/lib64', '/usr/lib'], 'sepol')
+
+    if dynamic_sepol is None:
+        print('Unable to find a libsepol.so on your system!')
+        print('Please set the SEPOL environment variable. Exiting.')
+        exit(1)
+
     static_sepol = dynamic_sepol.replace(".so", ".a")
 
 if sys.platform.startswith('darwin'):


### PR DESCRIPTION
The setup.py script attempts to locate the 'libsepol.so' library if the SEPOL environment variable is not set, but does not fail safely if the find fails. This commit adds error checking if the 'libsepol.so' is not located.