### PR TITLE
Make "search -A" output reproducible

### DIFF
--- a/setools/policyrep/terule.py
+++ b/setools/policyrep/terule.py
@@ -164,7 +164,7 @@ class AVRule(BaseTERule):
             # allow/dontaudit/auditallow/neverallow rules
             perms = self.perms
             if len(perms) > 1:
-                self._rule_string += "{{ {0} }};".format(' '.join(perms))
+                self._rule_string += "{{ {0} }};".format(' '.join(sorted(perms)))
             else:
                 # convert to list since sets cannot be indexed
                 self._rule_string += "{0};".format(list(perms)[0])


### PR DESCRIPTION
With Python 3, the values in a set are randomly organised. Therefore the representation of the set of permissions of an allow/dontaudit/... statement is not stable across execution.

Sort the permissions when converting them as strings.