### PR TITLE
Mark append as a 10 in the perm_map file.

### DIFF
--- a/setools/perm_map
+++ b/setools/perm_map
@@ -35,7 +35,7 @@ class netlink_audit_socket 27
       nlmsg_readpriv         r        10
          nlmsg_write         w        10
           nlmsg_read         r        10
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -64,7 +64,7 @@ class tcp_socket 27
            node_bind         n         1
              newconn         w         1
         name_connect         w         1
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -128,7 +128,7 @@ class dir 25
              execmod         n         1
               search         r         1
                 open         n         1
-              append         w         1
+              append         w        10
               create         w         1
              execute         r         1
                write         w        10
@@ -153,7 +153,7 @@ class blk_file 20
         audit_access         r         1
              execmod         n         1
                 open         n         1
-              append         w         1
+              append         w        10
               create         w         1
              execute         r         1
                write         w        10
@@ -177,7 +177,7 @@ class chr_file 22
              execmod         n         1
     execute_no_trans         r         1
                 open         n         1
-              append         w         1
+              append         w        10
               create         w         1
              execute         r         1
                write         w        10
@@ -236,7 +236,7 @@ class lnk_file 20
         audit_access         r         1
              execmod         n         1
                 open         n         1
-              append         w         1
+              append         w        10
               create         w         1
              execute         r         1
                write         w        10
@@ -307,7 +307,7 @@ class packet 7
              flow_in         r        10
 
 class socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -334,7 +334,7 @@ class fifo_file 20
         audit_access         r         1
              execmod         n         1
                 open         n         1
-              append         w         1
+              append         w        10
               create         w         1
              execute         r         1
                write         w        10
@@ -358,7 +358,7 @@ class file 22
              execmod         n         1
     execute_no_trans         r         1
                 open         n         1
-              append         w         1
+              append         w        10
               create         w         1
              execute         r         1
                write         w        10
@@ -416,7 +416,7 @@ class db_view 7
            relabelto         w         1
 
 class netlink_nflog_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -451,7 +451,7 @@ class key 7
 class netlink_tcpdiag_socket 24
          nlmsg_write         w        10
           nlmsg_read         r        10
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -478,7 +478,7 @@ class unix_stream_socket 25
           acceptfrom         r         1
            connectto         w         1
              newconn         w         1
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -535,7 +535,7 @@ class kernel_service 2
 class netlink_route_socket 24
          nlmsg_write         w        10
           nlmsg_read         r        10
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -590,7 +590,7 @@ class x_resource 2
                 read         r        10
 
 class netlink_selinux_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -650,7 +650,7 @@ class capability 32
 class netlink_ip6fw_socket 24
          nlmsg_write         w        10
           nlmsg_read         r        10
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -676,7 +676,7 @@ class netlink_ip6fw_socket 24
 class dccp_socket 24
            node_bind         n         1
         name_connect         w        10
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -702,7 +702,7 @@ class dccp_socket 24
 class netlink_firewall_socket 24
          nlmsg_write         w        10
           nlmsg_read         r        10
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -729,7 +729,7 @@ class sock_file 20
         audit_access         r         1
              execmod         n         1
                 open         n         1
-              append         w         1
+              append         w        10
               create         w         1
              execute         r         1
                write         w        10
@@ -748,7 +748,7 @@ class sock_file 20
               swapon         b         1
 
 class unix_dgram_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -772,7 +772,7 @@ class unix_dgram_socket 22
               listen         r         1
 
 class netlink_kobject_uevent_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -822,7 +822,7 @@ class filesystem 10
 class netlink_xfrm_socket 24
          nlmsg_write         w        10
           nlmsg_read         r        10
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -878,7 +878,7 @@ class db_schema 9
            relabelto         r         1
 
 class netlink_dnrt_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -950,7 +950,7 @@ class x_font 6
                  use         r         1
 
 class key_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -986,7 +986,7 @@ class netif 10
            dccp_send         w        10
 
 class packet_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -1018,7 +1018,7 @@ class msg 2
 
 class tun_socket 23
         attach_queue         w         5
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -1043,7 +1043,7 @@ class tun_socket 23
 
 class udp_socket 23
            node_bind         n         1
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -1067,7 +1067,7 @@ class udp_socket 23
               listen         r         1
 
 class appletalk_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -1114,7 +1114,7 @@ class x_screen 8
 
 class rawip_socket 23
            node_bind         n         1
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -1166,7 +1166,7 @@ class db_column 9
            relabelto         w         1
 
 class netlink_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -1300,7 +1300,7 @@ class binder 4
          impersonate         n         1
 
 class netlink_connector_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -1324,7 +1324,7 @@ class netlink_connector_socket 22
               listen         r         1
 
 class netlink_netfilter_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -1348,7 +1348,7 @@ class netlink_netfilter_socket 22
               listen         r         1
 
 class netlink_iscsi_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -1381,7 +1381,7 @@ class db_exception 7
                  use         r         1
 
 class netlink_rdma_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -1405,7 +1405,7 @@ class netlink_rdma_socket 22
               listen         r         1
 
 class netlink_generic_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -1429,7 +1429,7 @@ class netlink_generic_socket 22
               listen         r         1
 
 class netlink_scsitransport_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -1461,7 +1461,7 @@ class service 6
                 stop         w         1
 
 class netlink_crypto_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1
@@ -1494,7 +1494,7 @@ class db_datatype 7
                  use         r         1
 
 class netlink_fib_lookup_socket 22
-              append         w         1
+              append         w        10
                 bind         w         1
              connect         w         1
               create         w         1


### PR DESCRIPTION
I checked and it looks like append has been a 1 for permission weighting since
the very beginning. But that makes no sense - append lets you write to files.
So this should be a 10.

I changed all instances of append but, honestly, I'm not clear on many of them.

I did verify that if you open a file with O_APPEND and then write to that file
you only need append - you don't need write. Here is my test program:

int main(int argc, char** argv) {
  int fd = open("test_file", O_APPEND | O_CREAT | O_WRONLY, S_IRWXU | S_IRWXG);
  char buf[256];

  ssize_t b = write(fd, buf, 256);
  printf("%zd\n", b);
}

Running this in a domain with no permissions shows that we need:

allow lprog user_home_dir_t:file { append create open };

Which is what I expected - but this being wrong for so long made me question
my understanding of how this worked.