### PR TITLE
bswap_* macros are defined in byteswap.h

### DIFF
--- a/libqpol/policy.c
+++ b/libqpol/policy.c
@@ -28,6 +28,7 @@
 
 #include "qpol_internal.h"
 #include <assert.h>
+#include <byteswap.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <limits.h>


### PR DESCRIPTION
Fixes ImportError on s390x:
/usr/lib64/python3.6/site-packages/setools/policyrep/_qpol.cpython-36m-s390x-linux-gnu.so: undefined symbol: bswap_32