### PR TITLE
Document that build_ext needs to be run before build

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ of the SETools soures, perform the following:
 Unpack the official distribution or check out the git repository,
 and perform the following at the root:
 ```
+  $ python setup.py build_ext
   $ python setup.py build
   $ python setup.py install
 ```
@@ -104,6 +105,7 @@ set the SEPOL_SRC environmental variable to the path to the root of
 libsepol source tree:
 ```
   $ export SEPOL_SRC=/home/user/src/selinux/libsepol
+  $ python setup.py build_ext
   $ python setup.py build
   $ python setup.py install
 ```


### PR DESCRIPTION
When installing setools with python setup.py install,
setools/policyrep/qpol.py is not copied to the destination directory.
This is because the file is generated in step build_ext and Python files
are copied beforehand (in step build_py).

A simple workaround consists in running "setup.py build_ext" before
building and installing setools. Document this in the README.

Closes: https://github.com/TresysTechnology/setools/issues/173