### PR TITLE
Add support for SCTP protocol

### DIFF
--- a/libqpol/include/qpol/linux_types.h
+++ b/libqpol/include/qpol/linux_types.h
@@ -12,6 +12,7 @@ typedef uint16_t __u16;
 #define s6_addr32	__u6_addr32
 
 #define IPPROTO_DCCP 33
+#define IPPROTO_SCTP 132
 #endif
 
 #endif

--- a/libqpol/policy_define.c
+++ b/libqpol/policy_define.c
@@ -44,6 +44,9 @@
 #ifndef IPPROTO_DCCP
 #define IPPROTO_DCCP 33
 #endif
+#ifndef IPPROTO_SCTP
+#define IPPROTO_SCTP 132
+#endif
 #include <arpa/inet.h>
 #include <stdlib.h>
 #include <limits.h>
@@ -4933,6 +4936,8 @@ int define_port_context(unsigned int low, unsigned int high)
 		protocol = IPPROTO_UDP;
 	} else if ((strcmp(id, "dccp") == 0) || (strcmp(id, "DCCP") == 0)) {
 		protocol = IPPROTO_DCCP;
+	} else if ((strcmp(id, "sctp") == 0) || (strcmp(id, "SCTP") == 0)) {
+		protocol = IPPROTO_SCTP;
 	} else {
 		yyerror2("unrecognized protocol %s", id);
 		goto bad;

--- a/setools/perm_map
+++ b/setools/perm_map
@@ -385,6 +385,8 @@ class node 11
             udp_send         w        10
            dccp_recv         r        10
            dccp_send         w        10
+           sctp_recv         r        10
+           sctp_send         w        10
         enforce_dest         n         1
               sendto         w        10
             recvfrom         r        10
@@ -699,6 +701,32 @@ class dccp_socket 24
            relabelto         w        10
               listen         r         1
 
+class sctp_socket 24
+           node_bind         n         1
+        name_connect         w        10
+              append         w        10
+                bind         w         1
+             connect         w         1
+              create         w         1
+               write         w        10
+         relabelfrom         r        10
+               ioctl         n         1
+           name_bind         n         1
+              sendto         w        10
+            recv_msg         r        10
+            send_msg         w        10
+             getattr         r         7
+             setattr         w         7
+              accept         r         1
+              getopt         r         1
+                read         r        10
+              setopt         w         1
+            shutdown         w         1
+            recvfrom         r        10
+                lock         n         1
+           relabelto         w        10
+              listen         r         1
+
 class netlink_firewall_socket 24
          nlmsg_write         w        10
           nlmsg_read         r        10
@@ -984,6 +1012,8 @@ class netif 10
             udp_send         w        10
            dccp_recv         r        10
            dccp_send         w        10
+           sctp_recv         r        10
+           sctp_send         w        10
 
 class packet_socket 22
               append         w        10

--- a/setools/policyrep/netcontext.py
+++ b/setools/policyrep/netcontext.py
@@ -38,6 +38,10 @@ try:
     IPPROTO_DCCP = getprotobyname("dccp")
 except socket.error:
     IPPROTO_DCCP = 33
+try:
+    IPPROTO_SCTP = getprotobyname("sctp")
+except socket.error:
+    IPPROTO_SCTP = 132
 
 
 def netifcon_factory(policy, name):
@@ -196,6 +200,7 @@ class PortconProtocol(int, PolicyEnum):
     tcp = IPPROTO_TCP
     udp = IPPROTO_UDP
     dccp = IPPROTO_DCCP
+    sctp = IPPROTO_SCTP
 
 
 class Portcon(NetContext):


### PR DESCRIPTION
The changes in setools/policyrep/netcontext.py are necessary for "sepolicy manpage" to work on policy with SCTP portcon definitions. Otherwise the following exception is raised when creating PortconProtocol object:
ValueError: 132 is not a valid PortconProtocol